### PR TITLE
Fix deserialization issue when parameter value is array

### DIFF
--- a/allure-pytest-bdd/src/utils.py
+++ b/allure-pytest-bdd/src/utils.py
@@ -49,4 +49,4 @@ def get_pytest_report_status(pytest_report):
 def get_params(node):
     if hasattr(node, 'callspec'):
         params = node.callspec.params
-        return [Parameter(name=name, value=value) for name, value in params.items()]
+        return [Parameter(name=name, value=str(value)) for name, value in params.items()]


### PR DESCRIPTION
### Context
If you have custom converters and convert a parameter string into array, allure will throw below exception
```Could not read test result file allure\e3769575-aa8f-404e-9068-732f53e6db7c-result.json
com.fasterxml.jackson.databind.exc.MismatchedInputException: Cannot deserialize value of type `java.lang.String` from Array value (token `JsonToken.START_ARRAY`)
 at [Source: (sun.nio.ch.ChannelInputStream); line: 1, column: 15070] (through reference chain: io.qameta.allure.model.TestResult["parameters"]->java.util.ArrayList[2]->io.qameta.allure.model.Parameter["value"])
        at com.fasterxml.jackson.databind.exc.MismatchedInputException.from(MismatchedInputException.java:59)
```

This PR fixes the issue

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
